### PR TITLE
style: streamline bper parser comments

### DIFF
--- a/packages/sync-server/src/app-gocardless/banks/bper_retail_bpmoit22.js
+++ b/packages/sync-server/src/app-gocardless/banks/bper_retail_bpmoit22.js
@@ -1,26 +1,6 @@
 /**
- * BPER Bank Transaction Parser for Actual Budget
- *
- * ⚠️ Why this is needed:
- * -----------------------
- * BPER's GoCardless feed does not return structured payee/beneficiary fields.
- * Instead, *all transaction details* (merchant name, originator, creditor, etc.)
- * are crammed into a single string field: `remittanceInformationUnstructured`.
- *
- * Without preprocessing, Actual shows the full raw string as the payee,
- * which makes the register messy and hard to use.
- *
- * This parser extracts a cleaner `payee` based on the transaction type,
- * while keeping the original description in `memo`.
- *
- * Categories handled:
- *  1. Card payments        → extract merchant name after "PAGAMENTO SU CIRCUITO INTERNAZIONALE"
- *                            and before "Operazione carta"
- *  2. Bonifico transfers   → extract originator after "o/c:"
- *  3. Bonifici esteri      → same as bonifico
- *  4. SDD direct debits    → extract creditor name after "ADDEBITO SDD"
- *  5. Bollettini/Utilities → extract creditor after "CREDITORE:"
- *  6. Other (fees, misc)   → leave description as-is
+ * Normalize BPER Retail BPMOIT22 transactions by extracting a friendly payee
+ * while keeping the raw description in the notes field.
  */
 
 import Fallback from './integration-bank.js';
@@ -32,42 +12,33 @@ const BONIFICO_ESTERI_PREFIX = 'BONIFICI ESTERI';
 const SDD_PREFIX = 'ADDEBITO SDD';
 const BOLLETTINO_MARKER = 'CREDITORE:';
 
-const PAYEE_CAPTURE = "[A-Z0-9\\s.'\\/&-]+";
-const BONIFICO_ORIGINATOR_REGEX = new RegExp(
-  `o/c:\\s*(${PAYEE_CAPTURE}?)(?:ABI|BIC|IBAN|a favore di|Num|EUR|$)`,
-  'i',
-);
-const SDD_PAYEE_REGEX = new RegExp(
-  `ADDEBITO SDD\\s+(${PAYEE_CAPTURE}?)(?:N:|ID:|$)`,
-  'i',
-);
-const BOLLETTINO_PAYEE_REGEX = new RegExp(
-  `CREDITORE:\\s*(${PAYEE_CAPTURE})`,
-  'i',
-);
+const BONIFICO_ORIGINATOR_REGEX =
+  /o\/c:\s*([A-Z0-9\s.'/&-]+?)(?:ABI|BIC|IBAN|a favore di|Num|EUR|$)/i;
+const SDD_PAYEE_REGEX = /ADDEBITO SDD\s+([A-Z0-9\s.'/&-]+?)(?:N:|ID:|$)/i;
+const BOLLETTINO_PAYEE_REGEX = /CREDITORE:\s*([A-Z0-9\s.'/&-]+)/i;
 
-/** Extract payee for card transactions */
+// Extract payee for card transactions
 function parseCardPayee(description) {
   const [beforeSuffix] = description.split(CARD_PAYMENT_SUFFIX);
 
   return beforeSuffix.replace(CARD_PAYMENT_PREFIX, '').trim();
 }
 
-/** Extract originator for bonifico (domestic/foreign transfers) */
+// Extract originator for bonifico (domestic/foreign transfers)
 function parseBonificoOriginator(description) {
   const match = description.match(BONIFICO_ORIGINATOR_REGEX);
 
   return match ? match[1].trim() : '';
 }
 
-/** Extract creditor for SDD direct debits */
+// Extract creditor for SDD direct debits
 function parseSddPayee(description) {
   const match = description.match(SDD_PAYEE_REGEX);
 
   return match ? match[1].trim() : '';
 }
 
-/** Extract creditor for bollettini / utilities */
+// Extract creditor for bollettini / utilities
 function parseBollettinoPayee(description) {
   const match = description.match(BOLLETTINO_PAYEE_REGEX);
 
@@ -83,10 +54,6 @@ function setPayee(editedTransaction, payee) {
   editedTransaction.debtorName = payee;
 }
 
-/**
- * Main parser exported to Actual.
- * Maps a raw GoCardless BPER transaction into Actual's format.
- */
 /** @type {import('./bank.interface.js').IBank} */
 const BperRetailBank = {
   ...Fallback,
@@ -95,7 +62,9 @@ const BperRetailBank = {
 
   normalizeTransaction(transaction, booked) {
     const editedTrans = { ...transaction };
-    const description = (transaction.remittanceInformationUnstructured || '').trim();
+    const description = (
+      transaction.remittanceInformationUnstructured || ''
+    ).trim();
 
     if (description) {
       editedTrans.remittanceInformationUnstructured = description;

--- a/packages/sync-server/src/app-gocardless/banks/tests/bper_retail_bpmoit22.spec.js
+++ b/packages/sync-server/src/app-gocardless/banks/tests/bper_retail_bpmoit22.spec.js
@@ -95,9 +95,7 @@ describe('BPER Retail BPMOIT22', () => {
         true,
       );
 
-      expect(normalizedTransaction.payeeName).toEqual(
-        'Utility Company S.P.A.',
-      );
+      expect(normalizedTransaction.payeeName).toEqual('Utility Company S.P.A.');
       expect(normalizedTransaction.notes).toEqual(
         'PAGAMENTI DIVERSI DA INTERNET BANKING E CSA PAGAMENTO BOLLETTINO POSTALE 420251388002409360 DEL 22/06/2025 TRAMITE I.B. / CSA TIPO : 896 CCPOST : 000000000000 CREDITORE: UTILITY COMPANY S.P.A.',
       );
@@ -118,9 +116,7 @@ describe('BPER Retail BPMOIT22', () => {
       expect(normalizedTransaction.payeeName).toEqual(
         'Competenze Spese Ed Oneri',
       );
-      expect(normalizedTransaction.notes).toEqual(
-        'COMPETENZE SPESE ED ONERI',
-      );
+      expect(normalizedTransaction.notes).toEqual('COMPETENZE SPESE ED ONERI');
     });
   });
 });


### PR DESCRIPTION
## Summary
- replace the verbose BPER parser header with a concise JSDoc comment that matches other bank integrations
- switch helper annotations to line comments and inline the regex literals to match repository style

## Testing
- yarn prettier --check packages/sync-server/src/app-gocardless/banks/bper_retail_bpmoit22.js packages/sync-server/src/app-gocardless/banks/tests/bper_retail_bpmoit22.spec.js
- yarn eslint packages/sync-server/src/app-gocardless/banks/bper_retail_bpmoit22.js packages/sync-server/src/app-gocardless/banks/tests/bper_retail_bpmoit22.spec.js

------
https://chatgpt.com/codex/tasks/task_e_68cbfc3add9c8320a3df754d6871fd53